### PR TITLE
Hide event boxes on select

### DIFF
--- a/client/app/js/modules/common/services/styles-service.js
+++ b/client/app/js/modules/common/services/styles-service.js
@@ -5,7 +5,7 @@ angular.module('genie.common')
     return {
       boxHighlight: {
         strokeColor: 'red',
-        strokeOpacity: 0.8,
+        strokeOpacity: 0.7,
         strokeWeight: 2,
         fillColor: 'red',
         fillOpacity: 0.25,
@@ -13,10 +13,18 @@ angular.module('genie.common')
       },
       boxDefault: {
         strokeColor: 'yellow',
-        strokeOpacity: 0.8,
+        strokeOpacity: 0.6,
         strokeWeight: 2,
         fillColor: 'yellow',
-        fillOpacity: 0.25,
+        fillOpacity: 0.05,
+        zIndex: 1
+      },
+      boxMuted: {
+        strokeColor: 'yellow',
+        strokeOpacity: 0.4,
+        strokeWeight: 1,
+        fillColor: 'yellow',
+        fillOpacity: 0,
         zIndex: 1
       },
       darkColor: '#181818',

--- a/client/app/js/modules/events-map/directives/events-list-directive.js
+++ b/client/app/js/modules/events-map/directives/events-list-directive.js
@@ -77,9 +77,11 @@ angular.module('genie.eventsMap')
     }
 
     scope.selectEvent = function(event) {
-      // removeArtifacts();
       ImageManagerService.clear();
+      // revert previous highlight
+      let prevEvent = scope.selectedEvent;
       scope.selectedEvent = event;
+      scope.highlightEventBox(prevEvent, { revert: true });
       showEvent(event);
     };
 
@@ -278,16 +280,16 @@ angular.module('genie.eventsMap')
       }
     }
 
-    scope.highlightEventBox = function(event, options) {
-      options = options || {};
-      var box = _.detect(boxes, function(b) {
-        return b.customId === event.event_id;
-      });
+    scope.highlightEventBox = (event, options={}) => {
+      if (!event) return;
+      let box = _.detect(boxes, b => b.customId === event.event_id);
       if (!box) return;
-      options.revert ?
-        box.setOptions(StylesService.boxMuted)
-        :
+      if (options.revert) {
+        if (scope.selectedEvent !== event)
+          box.setOptions(StylesService.boxMuted);
+      } else {
         box.setOptions(StylesService.boxHighlight);
+      }
     };
 
     function drawBoxes(events) {

--- a/client/app/js/modules/events-map/directives/events-list-directive.js
+++ b/client/app/js/modules/events-map/directives/events-list-directive.js
@@ -81,7 +81,15 @@ angular.module('genie.eventsMap')
       ImageManagerService.clear();
       scope.selectedEvent = event;
       showEvent(event);
+      muteOtherBoxes(event);
     };
+
+    function muteOtherBoxes(event) {
+      boxes.forEach(box => {
+        if (box.customId !== event.event_id)
+          box.setOptions(StylesService.boxMuted);
+      });
+    }
 
     function showEvent(event) {
       if (event.event_source == 'hashtag') {
@@ -281,11 +289,11 @@ angular.module('genie.eventsMap')
     scope.highlightEventBox = function(event, options) {
       options = options || {};
       var box = _.detect(boxes, function(b) {
-        return b.__customId === event.event_id;
+        return b.customId === event.event_id;
       });
       if (!box) return;
       options.revert ?
-        box.setOptions(StylesService.boxDefault)
+        box.setOptions(StylesService.boxMuted)
         :
         box.setOptions(StylesService.boxHighlight);
     };
@@ -310,8 +318,8 @@ angular.module('genie.eventsMap')
           west: bb.sw.lng - 0.002
         }
       });
-      box.setOptions(StylesService.boxDefault);
-      box.__customId = event.event_id; // find by eventid later
+      box.setOptions(StylesService.boxMuted);
+      box.customId = event.event_id; // find by eventid later
       boxes.push(box);
     }
 

--- a/client/app/js/modules/events-map/directives/events-list-directive.js
+++ b/client/app/js/modules/events-map/directives/events-list-directive.js
@@ -81,15 +81,7 @@ angular.module('genie.eventsMap')
       ImageManagerService.clear();
       scope.selectedEvent = event;
       showEvent(event);
-      muteOtherBoxes(event);
     };
-
-    function muteOtherBoxes(event) {
-      boxes.forEach(box => {
-        if (box.customId !== event.event_id)
-          box.setOptions(StylesService.boxMuted);
-      });
-    }
 
     function showEvent(event) {
       if (event.event_source == 'hashtag') {


### PR DESCRIPTION
fix #76 

@drJAGartner See below

I tried a couple of iterations of this and settled on simply muting the initial colors (mostly just removing the fill color). Because...

1. I don't want to stray too far from the behavior of sandbox. We seem to do better if we just mimic sandbox.
1. I can't think of a user-friendly way to unhide the boxes back once they've been hidden.... When the user hovers over another event? or... Always hide them once the first item is selected, altho you might create a sort of whack-a-mole UX, not knowing where the initially displayed events are.
1. See below. We can bypass probably the biggest UX issue, which was that you couldn't see what was under the boxes, esp. when many overlapped. Now you can. Thoughts?

![image](https://cloud.githubusercontent.com/assets/12628/15727760/5d37a89e-281e-11e6-9007-731eed5d2f68.png)
